### PR TITLE
Report component errors while InProgress

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='sfdclib',
-    version='0.2.27',
+    version='0.2.28',
     author='Andrey Shevtsov & KevOps',
     author_email='ah.you@thought.com',
     packages=['sfdclib'],

--- a/sfdclib/metadata.py
+++ b/sfdclib/metadata.py
@@ -110,7 +110,7 @@ class SfdcMetadataApi:
 
         unit_test_errors = []
         deployment_errors = []
-        failed_count = result.find('mt:numberComponentErrors', self._XML_NAMESPACES)
+        failed_count = int(result.find('mt:numberComponentErrors', self._XML_NAMESPACES).text)
         if state == 'Failed' or failed_count > 0:
             # Deployment failures
             failures = result.findall('mt:details/mt:componentFailures', self._XML_NAMESPACES)
@@ -135,7 +135,7 @@ class SfdcMetadataApi:
 
         deployment_detail = {
             'total_count': result.find('mt:numberComponentsTotal', self._XML_NAMESPACES).text,
-            'failed_count': failed_count.text,
+            'failed_count': result.find('mt:numberComponentErrors', self._XML_NAMESPACES).text,
             'deployed_count': result.find('mt:numberComponentsDeployed', self._XML_NAMESPACES).text,
             'errors': deployment_errors
         }

--- a/sfdclib/metadata.py
+++ b/sfdclib/metadata.py
@@ -100,6 +100,13 @@ class SfdcMetadataApi:
 
         return result
 
+    @staticmethod
+    def get_component_error_count(value):
+        try:
+            return int(value)
+        except:
+            return 0
+
     def check_deploy_status(self, async_process_id):
         """ Checks whether deployment succeeded """
         result = self._retrieve_deploy_result(async_process_id)
@@ -110,7 +117,7 @@ class SfdcMetadataApi:
 
         unit_test_errors = []
         deployment_errors = []
-        failed_count = int(result.find('mt:numberComponentErrors', self._XML_NAMESPACES).text)
+        failed_count = self.get_component_error_count(result.find('mt:numberComponentErrors', self._XML_NAMESPACES).text)
         if state == 'Failed' or failed_count > 0:
             # Deployment failures
             failures = result.findall('mt:details/mt:componentFailures', self._XML_NAMESPACES)

--- a/sfdclib/metadata.py
+++ b/sfdclib/metadata.py
@@ -110,7 +110,8 @@ class SfdcMetadataApi:
 
         unit_test_errors = []
         deployment_errors = []
-        if state == 'Failed':
+        failed_count = result.find('mt:numberComponentErrors', self._XML_NAMESPACES)
+        if state == 'Failed' or failed_count > 0:
             # Deployment failures
             failures = result.findall('mt:details/mt:componentFailures', self._XML_NAMESPACES)
             for failure in failures:
@@ -134,7 +135,7 @@ class SfdcMetadataApi:
 
         deployment_detail = {
             'total_count': result.find('mt:numberComponentsTotal', self._XML_NAMESPACES).text,
-            'failed_count': result.find('mt:numberComponentErrors', self._XML_NAMESPACES).text,
+            'failed_count': failed_count.text,
             'deployed_count': result.find('mt:numberComponentsDeployed', self._XML_NAMESPACES).text,
             'errors': deployment_errors
         }


### PR DESCRIPTION
When checking the status of an `InProgress` deployment, component errors are not being added to the list of deployment errors. This causes an issue for the scheduled push upgrade step function because it cancels the deployment before it reaches the `Failed` state, and never receives the deployment errors.